### PR TITLE
feat: added jsonObjectsToBubbleThingsConverter utility function

### DIFF
--- a/jsonObjectsToBubbleThingsConverter.js
+++ b/jsonObjectsToBubbleThingsConverter.js
@@ -1,0 +1,50 @@
+const types = {
+    BOOLEAN: 'boolean',
+    DATE: 'date',
+    NUMBER: 'number',
+    TEXT: 'text',
+};
+
+const getValueType = (value) => {
+    const type = typeof value;
+
+    if (type === 'string') {
+        return types.TEXT;
+    }
+
+    if (type === 'boolean') {
+        return types.BOOLEAN;
+    }
+
+    if (type === 'number') {
+        // TODO: add check for returning types.DATE if number is a valid unix epoch timestamp
+        return types.NUMBER;
+    }
+};
+
+
+/*
+    A utility function to convert JSON received from API calls to a bubble data things JSON format.
+    It works by appending `_<typeof the value>` to the `key` of the object and helps us to get access to types in the editor. 
+*/
+const jsonObjectsToBubbleThingsConverter = (originalObject) => {
+    return Object.keys(originalObject).reduce((acc, key) => {
+        let newKeyName = `${key}_${getValueType(originalObject[key]) ?? ''}`;
+        acc[newKeyName] = originalObject[key];
+        return acc;
+    }, {})
+};
+
+
+/* --- Test --- */
+const testObject = {
+    name: "Alice",
+    age: 25,
+    city: "Wonderland",
+    isStudent: false
+};
+
+console.log("Original JSON Object:")
+console.log(testObject)
+console.log("\nGenerated Bubble Object:")
+console.log(jsonObjectsToBubbleThingsConverter(testObject))


### PR DESCRIPTION
## Changes
Added the jsonObjectsToBubbleThingsConverter utility function to easily convert JSON objects received from API calls to the bubble things format of JSON objects.

It works by appending `_<typeof the value>` to the `key` of the object and helps us to get access to types in the editor. 

Example:
<img width="634" alt="Screenshot 2024-10-30 at 12 57 59 PM" src="https://github.com/user-attachments/assets/272fce17-d06b-4047-abee-7f76ac61fe61">
